### PR TITLE
fix validate() to check for valid collector ID UUID #4

### DIFF
--- a/bindplane/sdk/source.go
+++ b/bindplane/sdk/source.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
+	"github.com/BlueMedoraPublic/bpcli/util/uuid"
 )
 
 // SourceConfigGet type describes a source configuration
@@ -174,8 +176,8 @@ func (s SourceConfigCreate) Validate() error {
 	if s.CollectionInterval < 1 {
 		msg = msg + "\ncollection interval cannot be less than 1"
 	}
-	if len(s.CollectorID) == 0 {
-		msg = msg + "\ncollector id is not present"
+	if !uuid.IsUUID(s.CollectorID) {
+		msg = msg + "\ncollector id is invalid"
 	}
 	if len(s.Credentials.Credentials) == 0 {
 		msg = msg + "\ncredentials are not present"

--- a/bindplane/sdk/source_test.go
+++ b/bindplane/sdk/source_test.go
@@ -186,7 +186,7 @@ func TestValidate(t *testing.T) {
 func getValidSourceConfigCreate() SourceConfigCreate {
 	var s SourceConfigCreate
 	s.CollectionInterval = 2
-	s.CollectorID = "abc"
+	s.CollectorID = "abcdefAB-0123-4ABC-ab12-CDEF01234567"
 	s.Credentials.Credentials = "abc"
 	s.Name = "abc"
 	s.SourceType = "abc"


### PR DESCRIPTION
Fixes #4
I updated validation rule for collector ID which check with `util/uuid.IsUUID()`