### PR TITLE
TestValidate error message improvements

### DIFF
--- a/bindplane/sdk/source_test.go
+++ b/bindplane/sdk/source_test.go
@@ -144,42 +144,54 @@ func TestValidate(t *testing.T) {
 	// test valid config
 	s = getValidSourceConfigCreate()
 	if s.Validate() != nil {
-		t.Errorf("Expected Validate() to not return an error when using a valid SourceConfigCreate struct")
+		t.Errorf("Expected Validate() to not return an error when using a valid SourceConfigCreate struct\n" +
+			"**VALIDATION ERROR MESSAGE**\n" +
+			s.Validate().Error())
 	}
 
 	// test collection interval
 	s = getValidSourceConfigCreate()
 	s.CollectionInterval = -1
 	if s.Validate() == nil {
-		t.Errorf("Expected Validate() to return an error when using an invalid collection interval")
+		t.Errorf("Expected Validate() to return an error when using an invalid collection interval" +
+			"**VALIDATION ERROR MESSAGE**\n" +
+			s.Validate().Error())
 	}
 
 	// test collector id
 	s = getValidSourceConfigCreate()
 	s.CollectorID = ""
 	if s.Validate() == nil {
-		t.Errorf("Expected Validate() to return an error when using an empty collector id")
+		t.Errorf("Expected Validate() to return an error when using an empty collector id" +
+			"**VALIDATION ERROR MESSAGE**\n" +
+			s.Validate().Error())
 	}
 
 	// test credentials
 	s = getValidSourceConfigCreate()
 	s.Credentials.Credentials = ""
 	if s.Validate() == nil {
-		t.Errorf("Expected Validate() to return an error when using an empty credential")
+		t.Errorf("Expected Validate() to return an error when using an empty credential" +
+			"**VALIDATION ERROR MESSAGE**\n" +
+			s.Validate().Error())
 	}
 
 	// test name
 	s = getValidSourceConfigCreate()
 	s.Name = ""
 	if s.Validate() == nil {
-		t.Errorf("Expected Validate() to return an error when using an empty name")
+		t.Errorf("Expected Validate() to return an error when using an empty name" +
+			"**VALIDATION ERROR MESSAGE**\n" +
+			s.Validate().Error())
 	}
 
 	// test source type
 	s = getValidSourceConfigCreate()
 	s.SourceType = ""
 	if s.Validate() == nil {
-		t.Errorf("Expected Validate() to return an error when using an empty source type")
+		t.Errorf("Expected Validate() to return an error when using an empty source type" +
+			"**VALIDATION ERROR MESSAGE**\n" +
+			s.Validate().Error())
 	}
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other review your Pull Request. -->

<!--- This template is based on github.com/zfsonlinux/zfs -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
TestValidate includes the error messages that are printed when the Validate() method fails.
It provides insight into where the validate method fails when tests are being run, if anything happens.
This solves the following issue: https://github.com/BlueMedoraPublic/bpcli/issues/7

### Description
<!--- Describe your changes in detail -->
The error message that is produced by the **Validate()** function was included on a new line for each case. 

### How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Ran `make test` several times while altering the values within **getValidSourceConfigCreate()** to ensure that failures produced error messages that included the message produced by the **Validate()** function. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code has been formatted with `make fmt` 
- [ ] I have updated the documentation.
- [x] I have added / updated tests to cover my changes.
- [x] All new and existing tests passed with `make test`
- [x] All commit messages are clear concise


