### PR TITLE
Simplify structs that have nested []structs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ bpcli
 *.json
 *.log
 
+*.cred
+*.source
+
 artifacts/
 bpcli_darwin_amd64
 bpcli_linux_amd64

--- a/bindplane/sdk/credential.go
+++ b/bindplane/sdk/credential.go
@@ -7,12 +7,12 @@ import (
 
 // Credential describes a source credential configuration
 type Credential struct {
-	ID               string      `json:"id"`
-	Name             string      `json:"name"`
-	URL              string      `json:"url"`
-	CredentialTypeID string      `json:"credential_type_id"`
-	Parameters       interface{} `json:"parameters"`
-	Sources []CredentialSource `json:"sources"`
+	ID               string             `json:"id"`
+	Name             string             `json:"name"`
+	URL              string             `json:"url"`
+	CredentialTypeID string             `json:"credential_type_id"`
+	Parameters       interface{}        `json:"parameters"`
+	Sources          []CredentialSource `json:"sources"`
 }
 
 // CredentialSource describes the soure object returned
@@ -42,10 +42,10 @@ type CredentialCreateResponse struct {
 
 // CredentialType describes a credential type object
 type CredentialType struct {
-	ID         string        `json:"id"`
-	Name       string        `json:"name"`
-	Parameters []interface{} `json:"parameters"`
-	Credentials []Credential `json:"credentials"`
+	ID          string        `json:"id"`
+	Name        string        `json:"name"`
+	Parameters  []interface{} `json:"parameters"`
+	Credentials []Credential  `json:"credentials"`
 }
 
 // CredentialTypeTemplate describes a credential type template object

--- a/bindplane/sdk/credential.go
+++ b/bindplane/sdk/credential.go
@@ -12,18 +12,22 @@ type Credential struct {
 	URL              string      `json:"url"`
 	CredentialTypeID string      `json:"credential_type_id"`
 	Parameters       interface{} `json:"parameters"`
-	Sources          []struct {
-		ID         string `json:"id"`
-		Name       string `json:"name"`
-		URL        string `json:"url"`
-		Stopped    bool   `json:"stopped"`
-		Status     string `json:"status"`
-		SourceType struct {
-			ID     string `json:"id"`
-			URL    string `json:"url"`
-			DocURL string `json:"doc_url"`
-		} `json:"source_type"`
-	} `json:"sources"`
+	Sources []CredentialSource `json:"sources"`
+}
+
+// CredentialSource describes the soure object returned
+// inside a Credential object's list of sources
+type CredentialSource struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	URL        string `json:"url"`
+	Stopped    bool   `json:"stopped"`
+	Status     string `json:"status"`
+	SourceType struct {
+		ID     string `json:"id"`
+		URL    string `json:"url"`
+		DocURL string `json:"doc_url"`
+	}
 }
 
 // CredentialCreateResponse type describes the json body returned
@@ -38,15 +42,10 @@ type CredentialCreateResponse struct {
 
 // CredentialType describes a credential type object
 type CredentialType struct {
-	ID          string        `json:"id"`
-	Name        string        `json:"name"`
-	Parameters  []interface{} `json:"parameters"`
-	Credentials []struct {
-		ID               string `json:"id"`
-		Name             string `json:"name"`
-		URL              string `json:"url"`
-		CredentialTypeID string `json:"credential_type_id"`
-	} `json:"credentials"`
+	ID         string        `json:"id"`
+	Name       string        `json:"name"`
+	Parameters []interface{} `json:"parameters"`
+	Credentials []Credential `json:"credentials"`
 }
 
 // CredentialTypeTemplate describes a credential type template object

--- a/bindplane/sdk/source.go
+++ b/bindplane/sdk/source.go
@@ -21,17 +21,12 @@ type SourceConfigGet struct {
 	} `json:"source_type"`
 	CollectionInterval int    `json:"collection_interval"`
 	CreatedAt          string `json:"created_at"`
-	Credentials        []struct {
-		ID               string `json:"id"`
-		Name             string `json:"name"`
-		URL              string `json:"url"`
-		CredentialTypeID string `json:"credential_type_id"`
-	} `json:"credentials"`
-	Configuration    interface{} `json:"configuration"`
-	Status           string      `json:"status"`
-	StatusReportedAt string      `json:"status_reported_at"`
-	StatusMessage    string      `json:"status_message"`
-	Stopped          bool        `json:"stopped"`
+	Credentials      []Credential `json:"credentials"`
+	Configuration    interface{}  `json:"configuration"`
+	Status           string       `json:"status"`
+	StatusReportedAt string       `json:"status_reported_at"`
+	StatusMessage    string       `json:"status_message"`
+	Stopped          bool         `json:"stopped"`
 	Collector        struct {
 		ID         string `json:"id"`
 		Name       string `json:"name"`
@@ -64,12 +59,8 @@ type SourceType struct {
 	DocURL                    string `json:"doc_url"`
 	Version                   string `json:"version"`
 	DefaultCollectionInterval int    `json:"default_collection_interval"`
-	CredentialTypes           []struct {
-		ID   string `json:"id"`
-		Name string `json:"name"`
-		URL  string `json:"url"`
-	} `json:"credential_types"`
-	ConnectionParameters interface{} `json:"connection_parameters"`
+	CredentialTypes      []CredentialType `json:"credential_types"`
+	ConnectionParameters interface{}      `json:"connection_parameters"`
 }
 
 // SourceTypeTemplate type describes a source type template configuration

--- a/bindplane/sdk/source.go
+++ b/bindplane/sdk/source.go
@@ -19,15 +19,15 @@ type SourceConfigGet struct {
 		URL    string `json:"url"`
 		DocURL string `json:"doc_url"`
 	} `json:"source_type"`
-	CollectionInterval int    `json:"collection_interval"`
-	CreatedAt          string `json:"created_at"`
-	Credentials      []Credential `json:"credentials"`
-	Configuration    interface{}  `json:"configuration"`
-	Status           string       `json:"status"`
-	StatusReportedAt string       `json:"status_reported_at"`
-	StatusMessage    string       `json:"status_message"`
-	Stopped          bool         `json:"stopped"`
-	Collector        struct {
+	CollectionInterval int          `json:"collection_interval"`
+	CreatedAt          string       `json:"created_at"`
+	Credentials        []Credential `json:"credentials"`
+	Configuration      interface{}  `json:"configuration"`
+	Status             string       `json:"status"`
+	StatusReportedAt   string       `json:"status_reported_at"`
+	StatusMessage      string       `json:"status_message"`
+	Stopped            bool         `json:"stopped"`
+	Collector          struct {
 		ID         string `json:"id"`
 		Name       string `json:"name"`
 		URL        string `json:"url"`
@@ -53,14 +53,14 @@ type SourceConfigCreate struct {
 
 // SourceType type describes a source type configuration
 type SourceType struct {
-	ID                        string `json:"id"`
-	Name                      string `json:"name"`
-	URL                       string `json:"url"`
-	DocURL                    string `json:"doc_url"`
-	Version                   string `json:"version"`
-	DefaultCollectionInterval int    `json:"default_collection_interval"`
-	CredentialTypes      []CredentialType `json:"credential_types"`
-	ConnectionParameters interface{}      `json:"connection_parameters"`
+	ID                        string           `json:"id"`
+	Name                      string           `json:"name"`
+	URL                       string           `json:"url"`
+	DocURL                    string           `json:"doc_url"`
+	Version                   string           `json:"version"`
+	DefaultCollectionInterval int              `json:"default_collection_interval"`
+	CredentialTypes           []CredentialType `json:"credential_types"`
+	ConnectionParameters      interface{}      `json:"connection_parameters"`
 }
 
 // SourceTypeTemplate type describes a source type template configuration

--- a/bindplane/sdk/source_test.go
+++ b/bindplane/sdk/source_test.go
@@ -168,45 +168,35 @@ func TestValidate(t *testing.T) {
 	s = getValidSourceConfigCreate()
 	s.CollectionInterval = -1
 	if s.Validate() == nil {
-		t.Errorf("Expected Validate() to return an error when using an invalid collection interval" +
-			"**VALIDATION ERROR MESSAGE**\n" +
-			s.Validate().Error())
+		t.Errorf("Expected Validate() to return an error when using an invalid collection interval")
 	}
 
 	// test collector id
 	s = getValidSourceConfigCreate()
 	s.CollectorID = ""
 	if s.Validate() == nil {
-		t.Errorf("Expected Validate() to return an error when using an empty collector id" +
-			"**VALIDATION ERROR MESSAGE**\n" +
-			s.Validate().Error())
+		t.Errorf("Expected Validate() to return an error when using an empty collector id")
 	}
 
 	// test credentials
 	s = getValidSourceConfigCreate()
 	s.Credentials.Credentials = ""
 	if s.Validate() == nil {
-		t.Errorf("Expected Validate() to return an error when using an empty credential" +
-			"**VALIDATION ERROR MESSAGE**\n" +
-			s.Validate().Error())
+		t.Errorf("Expected Validate() to return an error when using an empty credential")
 	}
 
 	// test name
 	s = getValidSourceConfigCreate()
 	s.Name = ""
 	if s.Validate() == nil {
-		t.Errorf("Expected Validate() to return an error when using an empty name" +
-			"**VALIDATION ERROR MESSAGE**\n" +
-			s.Validate().Error())
+		t.Errorf("Expected Validate() to return an error when using an empty name")
 	}
 
 	// test source type
 	s = getValidSourceConfigCreate()
 	s.SourceType = ""
 	if s.Validate() == nil {
-		t.Errorf("Expected Validate() to return an error when using an empty source type" +
-			"**VALIDATION ERROR MESSAGE**\n" +
-			s.Validate().Error())
+		t.Errorf("Expected Validate() to return an error when using an empty source type")
 	}
 }
 

--- a/bindplane/sdk/source_test.go
+++ b/bindplane/sdk/source_test.go
@@ -28,6 +28,21 @@ var testSource = strings.TrimRight(`{
   }
 }`, "\r\n")
 
+/*
+Ensure that SourceConfigGet uses []Credential rather than
+a nested []struct, as some packages importing this library
+may rely on this. Switching to a nested struct should be
+considered a breaking change.
+*/
+func SourceConfigGetType(t *testing.T) {
+	sourceConf := SourceConfigGet{}
+	cred := Credential{ID: "myid"}
+	sourceConf.Credentials = append(sourceConf.Credentials, cred)
+	if len(sourceConf.Credentials) != 1 {
+		t.Errorf("Expected sdk.SourceConfGet.Credentials to contain one credential object")
+	}
+}
+
 func TestListGetSources(t *testing.T) {
 	if liveTest() == false {
 		return


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other review your Pull Request. -->

<!--- This template is based on github.com/zfsonlinux/zfs -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

While working on the `terraform` provider, I found that some of my test cases would involve creating a `SourceConfigGet` struct from scratch (found in `bpcli/bindplane/sdk/source.go`). 

BPCLI uses the `encoding/json` package to convert an api response payload to this object. While this works well, it is difficult to do from scratch, particularly when dealing with nested []struct values.

### Description
<!--- Describe your changes in detail -->

It is much easier to create a `Credential` object and then append it to `SourceConfigGet.Credentials`. In order to do this, I needed breakup the `SourceConfigGet` struct. 

example pseudo code
```
var conf sdk.SourceConfigGet
var cred sdk.Credential

cred.ID = "some uuid"
conf.Credentials = append(conf.Credentials, cred)
```

It is not straight forward to do this if the `sdk.SourceConfigGet.Credentials` is a nested []struct, rather than a Credentials slice.

This is not a breaking change, and existing usage of `bpcli/bindplane/sdk` package's public interface remains the same.

### How Has This Been Tested?
<!--- Please describe how you tested your changes. -->

1) `make test` passes
2) using bpcli to configure db2 credential and source with a pre existing collector works great
3) deleting the db2 source and credential works great

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code has been formatted with `make fmt` 
- [ ] I have updated the documentation.
- [x] I have added / updated tests to cover my changes.
- [x] All new and existing tests passed with `make test`
- [x] All commit messages are clear concise


