### PR TITLE
skip credentialid validation if the credential length is zero

### DIFF
--- a/bindplane/sdk/source.go
+++ b/bindplane/sdk/source.go
@@ -179,8 +179,10 @@ func (s SourceConfigCreate) Validate() error {
 	if !uuid.IsUUID(s.CollectorID) {
 		msg = msg + "\ncollector id is invalid"
 	}
-	if !uuid.IsUUID(s.Credentials.Credentials) {
-		msg = msg + "\ncredentials id is not a valid UUID"
+	if len(s.Credentials.Credentials) > 0 {
+		if !uuid.IsUUID(s.Credentials.Credentials) {
+			msg = msg + "\ncredentials id is not a valid UUID"
+		}
 	}
 	if len(s.Name) == 0 {
 		msg = msg + "\nname is not present"

--- a/bindplane/sdk/source_test.go
+++ b/bindplane/sdk/source_test.go
@@ -164,8 +164,8 @@ func TestValidate(t *testing.T) {
 	// test credentials
 	s = getValidSourceConfigCreate()
 	s.Credentials.Credentials = ""
-	if s.Validate() == nil {
-		t.Errorf("Expected Validate() to return an error when using an empty credential")
+	if s.Validate() != nil {
+		t.Errorf("Expected Validate() to return a nil error when using an empty credential, not all sources require a credential")
 	}
 
 	// test name


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other review your Pull Request. -->

<!--- This template is based on github.com/zfsonlinux/zfs -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

If a credential's length is zero, the Validation() function for source create should skip checking the credential. This is because not all sources require a credential.

### Description
<!--- Describe your changes in detail -->

Updated Validate() to skip if credential length is not greater than 0.
Updated Validate() tests to check for a nil error when credential length is zero, instead of checking for an error. 

### How Has This Been Tested?
<!--- Please describe how you tested your changes. -->

`make test` passes

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code has been formatted with `make fmt` 
- [ ] I have updated the documentation.
- [x] I have added / updated tests to cover my changes.
- [x] All new and existing tests passed with `make test`
- [x] All commit messages are clear concise


