### PR TITLE
add watch feature for jobs. when passing --watch to 'bpcli job get', …

### DIFF
--- a/cmd/job_get.go
+++ b/cmd/job_get.go
@@ -3,6 +3,10 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
+	"time"
+
+	"github.com/BlueMedoraPublic/bpcli/bindplane/sdk"
 
 	"github.com/spf13/cobra"
 )
@@ -18,18 +22,40 @@ var getJobCmd = &cobra.Command{
 func init() {
 	jobCmd.AddCommand(getJobCmd)
 	getJobCmd.Flags().StringVar(&jobID, "id", "", "The ID of the job")
+	getJobCmd.Flags().BoolVarP(&watch, "watch", "", false, "Monitor the job's status in the forground until it has passed or failed.")
 	getJobCmd.MarkFlagRequired("id")
 }
 
 func getJob() {
-	j, err := bp.GetJob(jobID)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
-	}
+	for {
+		j, err := bp.GetJob(jobID)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err.Error())
+			os.Exit(1)
+		}
 
-	if err := j.Print(jsonFmt); err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
+		if err := j.Print(jsonFmt); err != nil {
+			fmt.Fprintln(os.Stderr, err.Error())
+			os.Exit(1)
+		}
+
+		// exit if watch not passed
+		if watch == false {
+			os.Exit(0)
+		}
+
+		// exit if job is finished
+		if jobFinished(j) == true {
+			os.Exit(0)
+		}
+		time.Sleep(time.Second * 5)
 	}
+}
+
+// return true if job is complete (passed or failed)
+func jobFinished(j sdk.Job) bool {
+	if strings.ToLower(j.Status) == "in progress" {
+		return false
+	}
+	return true
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ import (
 var sourceFile string
 var credentialFile string
 var jsonFmt bool
+var watch bool
 
 // uuid flags
 var jobID string


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other review your Pull Request. -->

<!--- This template is based on github.com/zfsonlinux/zfs -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It can be useful to have the terminal monitor the status of the job, until it is finished.

### Description
resolves https://github.com/BlueMedoraPublic/bpcli/issues/12

usage: `bpcli job get --id <uuid> --watch`

Watch will keep updating the terminal with the job status, until the job has passed or failed.

### How Has This Been Tested?
<!--- Please describe how you tested your changes. -->

manually ran `bpcli job get --id <uuid> --watch`

`make test` passes

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code has been formatted with `make fmt` 
- [ ] I have updated the documentation.
- [ ] I have added / updated tests to cover my changes.
- [x] All new and existing tests passed with `make test`
- [x] All commit messages are clear concise


