### PR TITLE
Configuration File for easy swapping between BindPlane accounts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,19 +16,12 @@ RUN \
     apt-get update >> /dev/null && \
     apt-get install -y golint zip
 
-ADD . /build/src/github.com/BlueMedoraPublic/bpcli
-
-# for compiling
-RUN go get github.com/mitchellh/gox
-
-# for command line
-RUN go get github.com/spf13/cobra
-
-# required for cobra, when compiling for Windows
-RUN go get github.com/inconshreveable/mousetrap
+ADD . /bpcli
+WORKDIR /bpcli
 
 # Disable CGO to avoid pulling in C dependencies, and compile for
 # MACOS, Linux, and Windows
+RUN go get github.com/mitchellh/gox
 RUN \
     env CGO_ENABLED=0 \
     $GOPATH/bin/gox \

--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,10 @@ build: clean
 	    -t bpcli:${VERSION} .
 
 	@docker create -ti --name bpcliartifacts bpcli:${VERSION} bash && \
-	    docker cp bpcliartifacts:/build/src/github.com/BlueMedoraPublic/bpcli/bpcli_linux_amd64.zip artifacts/bpcli_linux_amd64.zip && \
-	    docker cp bpcliartifacts:/build/src/github.com/BlueMedoraPublic/bpcli/bpcli_darwin_amd64.zip artifacts/bpcli_darwin_amd64.zip && \
-	    docker cp bpcliartifacts:/build/src/github.com/BlueMedoraPublic/bpcli/bpcli_windows_amd64.zip artifacts/bpcli_windows_amd64.zip && \
-	    docker cp bpcliartifacts:/build/src/github.com/BlueMedoraPublic/bpcli/SHA256SUMS artifacts/SHA256SUMS
+	    docker cp bpcliartifacts:/bpcli/bpcli_linux_amd64.zip artifacts/bpcli_linux_amd64.zip && \
+	    docker cp bpcliartifacts:/bpcli/bpcli_darwin_amd64.zip artifacts/bpcli_darwin_amd64.zip && \
+	    docker cp bpcliartifacts:/bpcli/bpcli_windows_amd64.zip artifacts/bpcli_windows_amd64.zip && \
+	    docker cp bpcliartifacts:/bpcli/SHA256SUMS artifacts/SHA256SUMS
 
 	# cleanup
 	@docker rm -fv bpcliartifacts &> /dev/null

--- a/Makefile
+++ b/Makefile
@@ -44,3 +44,6 @@ fmt:
 
 clean:
 	$(shell rm -rf artifacts/*)
+
+quick:
+	$(shell env CGO_ENABLED=0 go build)

--- a/README.md
+++ b/README.md
@@ -23,64 +23,6 @@ chmod +x bpcli
 mv bpcli /usr/local/bin
 ```
 
-## Configuration File
-bpcli now allows the user to change the account they are manipulating without
-having to always change the **BINDPLANE_API_KEY** environment variable by hand.
-
-**WARNING**
-If both the environment variable and configuration file exist, the environment
-variable will ALWAYS take precedence over the configuration file. To use the
-configuration file, make sure the environment variable has not already been exported/set in `~/.bash_profile`, `~/.bashrc`, etc. 
-
-#### Example Usage
-Adding and setting an account to be used by bpcli
-```
-bpcli account add --name=<ACCOUNT NAME> --id=<API_KEY>
-bpcli account set --name=<ACCOUNT_NAME>
-```
-
-List all accounts that have been added to the configuration file
-```
-bpcli account list
-```
-
-Remove an account from the configuration file
-```
-bpcli account remove --name=<ACCOUNT_NAME>
-```
-
-## Shell Completion
-
-#### Bash
-
-bash-completion v2 requires bash version 4+
-On MacOS, the default version is below 4 and will need to be updated!
-Follow these instructions on [Upgrading Bash on MacOS](https://itnext.io/upgrading-bash-on-macos-7138bd1066ba).
-
-To setup bash completion for bpcli on MacOS:
-1. Install *bash-completion* by running `brew install bash-completion@2`&nbsp;
-2. Include the following lines in `~/.bash_profile`&nbsp;
-```
-export BASH_COMPLETION_COMPAT_DIR="/usr/local/etc/bash_completion.d"
-[[ -r "/usr/local/etc/profile.d/bash_completion.sh" ]] && . "/usr/local/etc/profile.d/bash_completion.sh"
-```
-3. Run the following command to include the bash-completion script in `/usr/local/etc/bash_completion.d/`\
-`bpcli completion >/usr/local/etc/bash_completion.d/bpcli`
-4. Restart the shell and bpcli tab completions will be available
-
-#### ZSH
-
-To setup zsh completion for bpcli on MacOS:
-1. Include the following lines in `~/.zshrc`&nbsp;
-```
-autoload -Uz compinit
-compinit
-```
-2. Locate `fpath` by running `echo $fpath`
-3. Run the following command to generate the zsh tab completion script.\
-`bpcli completion --zsh ><YOUR FPATH HERE>/_bpcli`
-4. Restart zsh and the bpcli tab completions will be available.
-
 ## Usage
 bpcli uses [cobra](https://github.com/spf13/cobra) for managing
 commands and flags.
@@ -136,6 +78,65 @@ bpcli account add
 bpcli account set
 bpcli account remove
 ```
+
+## Credentials File
+bpcli allows the user to change the account they are manipulating by utilizing
+a credentials file.
+
+*Warning*
+The **BINDPLANE_API_KEY** environment variable will always take precedence over the
+credentials file, if it is present. 
+
+#### Example Usage
+Adding and setting an account to be used by bpcli
+The `set` command makes the given account the **Active** account and is
+required even when only one entry is present in the credentials file
+```
+bpcli account add --name=<ACCOUNT NAME> --id=<API_KEY>
+bpcli account set --name=<ACCOUNT_NAME>
+```
+
+List all accounts that have been added to the configuration file
+```
+bpcli account list
+```
+
+Remove an account from the configuration file
+```
+bpcli account remove --name=<ACCOUNT_NAME>
+```
+
+## Shell Completion
+
+#### Bash
+
+bash-completion v2 requires bash version 4+
+On MacOS, the default version is below 4 and will need to be updated!
+Follow these instructions on [Upgrading Bash on MacOS](https://itnext.io/upgrading-bash-on-macos-7138bd1066ba).
+
+To setup bash completion for bpcli on MacOS:
+1. Install *bash-completion* by running `brew install bash-completion@2`&nbsp;
+2. Include the following lines in `~/.bash_profile`&nbsp;
+```
+export BASH_COMPLETION_COMPAT_DIR="/usr/local/etc/bash_completion.d"
+[[ -r "/usr/local/etc/profile.d/bash_completion.sh" ]] && . "/usr/local/etc/profile.d/bash_completion.sh"
+```
+3. Run the following command to include the bash-completion script in `/usr/local/etc/bash_completion.d/`\
+`bpcli completion >/usr/local/etc/bash_completion.d/bpcli`
+4. Restart the shell and bpcli tab completions will be available
+
+#### ZSH
+
+To setup zsh completion for bpcli on MacOS:
+1. Include the following lines in `~/.zshrc`&nbsp;
+```
+autoload -Uz compinit
+compinit
+```
+2. Locate `fpath` by running `echo $fpath`
+3. Run the following command to generate the zsh tab completion script.\
+`bpcli completion --zsh ><YOUR FPATH HERE>/_bpcli`
+4. Restart zsh and the bpcli tab completions will be available.
 
 ## Developing
 

--- a/README.md
+++ b/README.md
@@ -179,10 +179,10 @@ Build with Docker, and check the artifacts directory when finished
 make
 ```
 
-To build on your own system, without Docker:
+To build on your own, without Docker, clone this repo *outside* of your GOPATH, as 
+bpcli uses go modules:
 ```
-go get ./...
-env CGO_ENABLED=0 go build
+env CGO_ENABLED=0 go build -a
 ```
 
 To cross compile on your own system, without Docker, set

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ having to always change the **BINDPLANE_API_KEY** environment variable by hand.
 **WARNING**
 If both the environment variable and configuration file exist, the environment
 variable will ALWAYS take precedence over the configuration file. To use the
-configuration file, make sure the environment variable has not already been set.
+configuration file, make sure the environment variable has not already been exported/set in `~/.bash_profile`, `~/.bashrc`, etc. 
 
 #### Example Usage
 Adding and setting an account to be used by bpcli

--- a/README.md
+++ b/README.md
@@ -23,6 +23,32 @@ chmod +x bpcli
 mv bpcli /usr/local/bin
 ```
 
+## Configuration File
+bpcli now allows the user to change the account they are manipulating without
+having to always change the **BINDPLANE_API_KEY** environment variable by hand.
+
+**WARNING**
+If both the environment variable and configuration file exist, the environment
+variable will ALWAYS take precedence over the configuration file. To use the
+configuration file, make sure the environment variable has not already been set.
+
+#### Example Usage
+Adding and setting an account to be used by bpcli
+```
+bpcli account add --name=<ACCOUNT NAME> --id=<API_KEY>
+bpcli account set --name=<ACCOUNT_NAME>
+```
+
+List all accounts that have been added to the configuration file
+```
+bpcli account list
+```
+
+Remove an account from the configuration file
+```
+bpcli account remove --name=<ACCOUNT_NAME>
+```
+
 ## Shell Completion
 
 #### Bash
@@ -103,7 +129,13 @@ bpcli collector group list
 bpcli job list
 bpcli job get
 ````
-
+#### Accounts
+```
+bpcli account list
+bpcli account add
+bpcli account set
+bpcli account remove
+```
 
 ## Developing
 

--- a/bindplane/sdk/bindplane.go
+++ b/bindplane/sdk/bindplane.go
@@ -4,7 +4,6 @@ import (
 	"github.com/BlueMedoraPublic/bpcli/bindplane/api"
 	"github.com/BlueMedoraPublic/bpcli/config"
 	"github.com/BlueMedoraPublic/bpcli/util/httpclient"
-	"github.com/BlueMedoraPublic/bpcli/util/uuid"
 	"github.com/pkg/errors"
 )
 
@@ -66,7 +65,7 @@ func (bp *BindPlane) setBaseURL() error {
 }
 
 func (bp *BindPlane) setAPIKey() error {
-	var apiKey string
+	// var apiKey string
 
 	// Checks current API Key string length
 	if len(bp.APIKey) == 0 {
@@ -76,11 +75,6 @@ func (bp *BindPlane) setAPIKey() error {
 		}
 		// Set API Key
 		bp.APIKey = apiKey
-	}
-
-	// If the API Key is not a valid UUID, return an error
-	if uuid.IsUUID(bp.APIKey) == false {
-		return errors.New("APIKey: " + apiKey + " is not a uuid. Is it correct?")
 	}
 
 	return nil

--- a/bindplane/sdk/bindplane.go
+++ b/bindplane/sdk/bindplane.go
@@ -70,7 +70,7 @@ func (bp *BindPlane) setAPIKey() error {
 
 	// Checks current API Key string length
 	if len(bp.APIKey) == 0 {
-		apiKey, err := config.GetCurrentAPIKey()
+		apiKey, err := config.CurrentAPIKey()
 		if err != nil {
 			return err
 		}

--- a/bindplane/sdk/bindplane.go
+++ b/bindplane/sdk/bindplane.go
@@ -1,12 +1,11 @@
 package sdk
 
 import (
-	"errors"
-	"os"
-
 	"github.com/BlueMedoraPublic/bpcli/bindplane/api"
+	"github.com/BlueMedoraPublic/bpcli/config"
 	"github.com/BlueMedoraPublic/bpcli/util/httpclient"
 	"github.com/BlueMedoraPublic/bpcli/util/uuid"
+	"github.com/pkg/errors"
 )
 
 // BindPlane type stores the global configuration
@@ -67,15 +66,21 @@ func (bp *BindPlane) setBaseURL() error {
 }
 
 func (bp *BindPlane) setAPIKey() error {
+	var apiKey string
+
+	// Checks current API Key string length
 	if len(bp.APIKey) == 0 {
-		bp.APIKey, _ = os.LookupEnv("BINDPLANE_API_KEY")
-		if len(bp.APIKey) == 0 {
-			return errors.New("You must set BINDPLANE_API_KEY in your environment")
+		apiKey, err := config.GetCurrentAPIKey()
+		if err != nil {
+			return err
 		}
+		// Set API Key
+		bp.APIKey = apiKey
 	}
 
+	// If the API Key is not a valid UUID, return an error
 	if uuid.IsUUID(bp.APIKey) == false {
-		return errors.New("APIKey: " + bp.APIKey + " is not a uuid. Is it correct?")
+		return errors.New("APIKey: " + apiKey + " is not a uuid. Is it correct?")
 	}
 
 	return nil

--- a/cmd/account.go
+++ b/cmd/account.go
@@ -1,0 +1,14 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var accountCmd = &cobra.Command{
+	Use:   "account",
+	Short: "Manage BindPlane accounts",
+}
+
+func init() {
+	rootCmd.AddCommand(accountCmd)
+}

--- a/cmd/account_add.go
+++ b/cmd/account_add.go
@@ -20,6 +20,8 @@ func init() {
 	accountCmd.AddCommand(addAccountCmd)
 	addAccountCmd.Flags().StringVar(&accountName, "name", "", "The name of the BindPlane account")
 	addAccountCmd.Flags().StringVar(&accountID, "id", "", "The BindPlane API Key")
+	setAccountCmd.MarkFlagRequired("name")
+	setAccountCmd.MarkFlagRequired("id")
 }
 
 func add() {

--- a/cmd/account_add.go
+++ b/cmd/account_add.go
@@ -10,7 +10,7 @@ import (
 
 var addAccountCmd = &cobra.Command{
 	Use:   "add",
-	Short: "Add a BindPlane account to the list",
+	Short: "Add a BindPlane account",
 	Run: func(cmd *cobra.Command, args []string) {
 		add()
 	},
@@ -20,14 +20,14 @@ func init() {
 	accountCmd.AddCommand(addAccountCmd)
 	addAccountCmd.Flags().StringVar(&accountName, "name", "", "The name of the BindPlane account")
 	addAccountCmd.Flags().StringVar(&accountID, "id", "", "The BindPlane API Key")
-	setAccountCmd.MarkFlagRequired("name")
-	setAccountCmd.MarkFlagRequired("id")
+	addAccountCmd.MarkFlagRequired("name")
+	addAccountCmd.MarkFlagRequired("id")
 }
 
 func add() {
-	err := config.AddAccount(accountName, accountID)
-	if err != nil {
+	if err := config.AddAccount(accountName, accountID); err != nil {
 		fmt.Fprint(os.Stderr, err.Error())
 		os.Exit(1)
 	}
+	fmt.Println(accountName + " has been successfully added")
 }

--- a/cmd/account_add.go
+++ b/cmd/account_add.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var addAccountCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add a BindPlane account to the list",
+}
+
+func init() {
+	accountCmd.AddCommand(addAccountCmd)
+	addAccountCmd.Flags().StringVar(&accountName, "name", "", "The name of the BindPlane account")
+	addAccountCmd.Flags().StringVar(&accountID, "id", "", "The BindPlane API Key")
+}

--- a/cmd/account_add.go
+++ b/cmd/account_add.go
@@ -1,16 +1,31 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+
+	"github.com/BlueMedoraPublic/bpcli/config"
 	"github.com/spf13/cobra"
 )
 
 var addAccountCmd = &cobra.Command{
 	Use:   "add",
 	Short: "Add a BindPlane account to the list",
+	Run: func(cmd *cobra.Command, args []string) {
+		add()
+	},
 }
 
 func init() {
 	accountCmd.AddCommand(addAccountCmd)
 	addAccountCmd.Flags().StringVar(&accountName, "name", "", "The name of the BindPlane account")
 	addAccountCmd.Flags().StringVar(&accountID, "id", "", "The BindPlane API Key")
+}
+
+func add() {
+	err := config.AddAccount(accountName, accountID)
+	if err != nil {
+		fmt.Fprint(os.Stderr, err.Error())
+		os.Exit(1)
+	}
 }

--- a/cmd/account_list.go
+++ b/cmd/account_list.go
@@ -21,8 +21,7 @@ func init() {
 }
 
 func list() {
-	err := config.ListAccounts()
-	if err != nil {
+	if err := config.ListAccounts(); err != nil {
 		fmt.Fprint(os.Stderr, err.Error())
 		os.Exit(1)
 	}

--- a/cmd/account_list.go
+++ b/cmd/account_list.go
@@ -1,0 +1,14 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var listAccountCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List available BindPlane accounts",
+}
+
+func init() {
+	accountCmd.AddCommand(listAccountCmd)
+}

--- a/cmd/account_list.go
+++ b/cmd/account_list.go
@@ -1,14 +1,29 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+
+	"github.com/BlueMedoraPublic/bpcli/config"
 	"github.com/spf13/cobra"
 )
 
 var listAccountCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List available BindPlane accounts",
+	Run: func(cmd *cobra.Command, args []string) {
+		list()
+	},
 }
 
 func init() {
 	accountCmd.AddCommand(listAccountCmd)
+}
+
+func list() {
+	err := config.ListAccounts()
+	if err != nil {
+		fmt.Fprint(os.Stderr, err.Error())
+		os.Exit(1)
+	}
 }

--- a/cmd/account_remove.go
+++ b/cmd/account_remove.go
@@ -1,20 +1,31 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/BlueMedoraPublic/bpcli/config"
 	"github.com/spf13/cobra"
 )
 
 var removeAccountCmd = &cobra.Command{
 	Use:   "remove",
-	Short: "Remove a BindPlane account from the list",
+	Short: "Remove a BindPlane account",
 	Run: func(cmd *cobra.Command, args []string) {
-		config.Remove(accountName)
+		remove()
 	},
 }
 
 func init() {
 	accountCmd.AddCommand(removeAccountCmd)
 	removeAccountCmd.Flags().StringVar(&accountName, "name", "", "The name of the BindPlane account")
-	setAccountCmd.MarkFlagRequired("name")
+	removeAccountCmd.MarkFlagRequired("name")
+}
+
+func remove() {
+	if err := config.Remove(accountName); err != nil {
+		fmt.Fprint(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+	fmt.Println(accountName + " has been successfully removed")
 }

--- a/cmd/account_remove.go
+++ b/cmd/account_remove.go
@@ -16,4 +16,5 @@ var removeAccountCmd = &cobra.Command{
 func init() {
 	accountCmd.AddCommand(removeAccountCmd)
 	removeAccountCmd.Flags().StringVar(&accountName, "name", "", "The name of the BindPlane account")
+	setAccountCmd.MarkFlagRequired("name")
 }

--- a/cmd/account_remove.go
+++ b/cmd/account_remove.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var removeAccountCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "Remove a BindPlane account from the list",
+}
+
+func init() {
+	accountCmd.AddCommand(removeAccountCmd)
+	removeAccountCmd.Flags().StringVar(&accountName, "name", "", "The name of the BindPlane account")
+}

--- a/cmd/account_remove.go
+++ b/cmd/account_remove.go
@@ -1,12 +1,16 @@
 package cmd
 
 import (
+	"github.com/BlueMedoraPublic/bpcli/config"
 	"github.com/spf13/cobra"
 )
 
 var removeAccountCmd = &cobra.Command{
 	Use:   "remove",
 	Short: "Remove a BindPlane account from the list",
+	Run: func(cmd *cobra.Command, args []string) {
+		config.Remove(accountName)
+	},
 }
 
 func init() {

--- a/cmd/account_set.go
+++ b/cmd/account_set.go
@@ -23,9 +23,9 @@ func init() {
 }
 
 func set() {
-	err := config.SetCurrent(accountName)
-	if err != nil {
+	if err := config.SetCurrent(accountName); err != nil {
 		fmt.Fprint(os.Stderr, err.Error())
 		os.Exit(1)
 	}
+	fmt.Println(accountName + " has successfully been set as current")
 }

--- a/cmd/account_set.go
+++ b/cmd/account_set.go
@@ -19,6 +19,7 @@ var setAccountCmd = &cobra.Command{
 func init() {
 	accountCmd.AddCommand(setAccountCmd)
 	setAccountCmd.Flags().StringVar(&accountName, "name", "", "The name of the BindPlane account")
+	setAccountCmd.MarkFlagRequired("name")
 }
 
 func set() {

--- a/cmd/account_set.go
+++ b/cmd/account_set.go
@@ -1,15 +1,30 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+
+	"github.com/BlueMedoraPublic/bpcli/config"
 	"github.com/spf13/cobra"
 )
 
 var setAccountCmd = &cobra.Command{
 	Use:   "set",
 	Short: "Set the BindPlane account to be used",
+	Run: func(cmd *cobra.Command, args []string) {
+		set()
+	},
 }
 
 func init() {
 	accountCmd.AddCommand(setAccountCmd)
 	setAccountCmd.Flags().StringVar(&accountName, "name", "", "The name of the BindPlane account")
+}
+
+func set() {
+	err := config.SetCurrent(accountName)
+	if err != nil {
+		fmt.Fprint(os.Stderr, err.Error())
+		os.Exit(1)
+	}
 }

--- a/cmd/account_set.go
+++ b/cmd/account_set.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var setAccountCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Set the BindPlane account to be used",
+}
+
+func init() {
+	accountCmd.AddCommand(setAccountCmd)
+	setAccountCmd.Flags().StringVar(&accountName, "name", "", "The name of the BindPlane account")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 )
 
 // flags
+var accountName string
 var sourceFile string
 var credentialFile string
 var jsonFmt bool
@@ -19,6 +20,7 @@ var zshCompletion bool
 var watch bool
 
 // uuid flags
+var accountID string
 var jobID string
 var groupID string
 var collectorID string
@@ -52,7 +54,7 @@ func init() {
 func initConfig() {
 	// avoid running bp.Init() if these commands were passed
 	// as argument one
-	y := []string{"help", "version", "completion"}
+	y := []string{"help", "version", "completion", "account"}
 	for _, subCmd := range y {
 		if subCmd == os.Args[1] {
 			return

--- a/config/config.go
+++ b/config/config.go
@@ -228,12 +228,12 @@ func SetCurrent(name string) error {
 func read() ([]account, error) {
 	accountList := []account{}
 
-	dir, err := homeDir()
+	filePath, err := configPath()
 	if err != nil {
 		return accountList, err
 	}
 
-	file, err := ioutil.ReadFile(dir + "/.bpcli")
+	file, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		return accountList, err
 	}
@@ -247,12 +247,12 @@ func read() ([]account, error) {
 // write is a helper function that will write/re-write the configuration file
 func write(list []byte) error {
 
-	dir, err := homeDir()
+	filePath, err := configPath()
 	if err != nil {
 		return err
 	}
 
-	return ioutil.WriteFile(dir+"/.bpcli", list, 0644)
+	return ioutil.WriteFile(filePath, list, 0644)
 }
 
 // uniqueUUID checks the account list for duplicate UUIDs
@@ -332,16 +332,18 @@ func hasCurrent() (bool, error) {
 	return false, nil
 }
 
-// homeDir returns the home directory of the current user
-func homeDir() (string, error) {
+// configPath returns the home directory of the current user
+func configPath() (string, error) {
+	x := os.Getenv("BINDPLANE_CONFIG_FILE")
+	if len(x) > 0 {
+		return x, nil
+	}
 
 	usr, err := user.Current()
 	if err != nil {
 		return "", err
 	}
-
-	dir := usr.HomeDir
-	return dir, nil
+	return usr.HomeDir + "/.bpcli", nil
 }
 
 // accountExists checks the config file to see whether a given account exists

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,379 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/user"
+
+	"github.com/BlueMedoraPublic/bpcli/util/uuid"
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+)
+
+// account stores users BindPlane account information
+type account struct {
+	Name    string `json:”name”`
+	Key     string `json:”key”`
+	Current bool   `json:”current”`
+}
+
+// ListAccounts prints a formatted list of users read from the configuration file
+func ListAccounts() error {
+
+	currentList, err := read()
+	if err != nil {
+		return err
+	}
+
+	if len(currentList) == 0 {
+		return errors.New(`the file is empty! try adding a new account to the list`)
+	}
+
+	fmt.Println("List of Account Names. * Denotes Current Account")
+
+	// Print the list in a formatted way
+	for _, acc := range currentList {
+		if acc.Current == true {
+			fmt.Println("* " + acc.Name)
+		} else {
+			fmt.Println(acc.Name)
+		}
+	}
+	return nil
+}
+
+// AddAccount appends an account to the configuration file
+func AddAccount(name string, key string) error {
+
+	currentList, err := read()
+	if err != nil {
+		return err
+	}
+
+	if !uuid.IsUUID(key) {
+		return errors.New("The API Key given is not a valid UUID")
+	}
+
+	b, err := uniqueUUID(key)
+	if err != nil {
+		return err
+	}
+	if b == false {
+		return errors.New("The API Key given already exists within the config file")
+	}
+
+	n, err := uniqueName(name)
+	if err != nil {
+		return err
+	}
+	if n == false {
+		return errors.New("The name given already exists within the config file")
+	}
+
+	a := account{Name: name, Key: key, Current: false}
+	newList := append(currentList, a)
+
+	newListBytes, err := json.Marshal(newList)
+	if err != nil {
+		return err
+	}
+
+	return write(newListBytes)
+}
+
+// Remove erases an account from the configuration file
+func Remove(name string) error {
+
+	currentList, err := read()
+	if err != nil {
+		return err
+	}
+
+	newList := currentList
+
+	if !(len(newList) > 0) {
+		return errors.New("The account list exists, but it is empty")
+	}
+
+	for i := 0; i < (len(newList)); i++ {
+		if name != newList[i].Name {
+			continue
+		} else {
+			newList = append(newList[:i], newList[i+1:]...)
+			break
+		}
+	}
+
+	if cmp.Equal(newList, currentList) {
+		fmt.Println("No names matched the given input\n" +
+			"Name Given: " + name + "\n")
+		return nil
+	}
+
+	newListBytes, err := json.Marshal(newList)
+	if err != nil {
+		return err
+	}
+
+	return write(newListBytes)
+}
+
+// GetCurrentAPIKey attempts to retrieve an API key
+func GetCurrentAPIKey() (string, error) {
+
+	errMsg := `To use bpcli you must do either of the following:
+	1. Set an environment variable named BINDPLANE_API_KEY
+	2. Define a configuration file`
+
+	// Check environment variable
+	apiKey, envExists := os.LookupEnv("BINDPLANE_API_KEY")
+
+	fileExists, _ := checkConfig()
+
+	// No env variable, no file
+	// Error
+	if !fileExists && !envExists {
+		return apiKey, errors.New("ERROR: The BINDPLANE_API_KEY environment variable is not present\n" +
+			"ERROR: The configuration file is not present\n" +
+			errMsg)
+	}
+
+	// Env variable exists, no file
+	if !fileExists && envExists {
+		if len(apiKey) <= 0 {
+			return apiKey, errors.New("ERROR: The environment variable is not set\n" +
+				errMsg)
+		}
+		if !uuid.IsUUID(apiKey) {
+			return apiKey, errors.New("ERROR: The API Key given is not a valid UUID\n" +
+				errMsg)
+		}
+		return apiKey, nil
+	}
+
+	// No env variable, config file w/o current set
+	// Error
+	if !envExists && fileExists {
+		b, err := hasCurrent()
+		if err != nil {
+			return apiKey, err
+		}
+		if b == false {
+			return apiKey, errors.New("ERROR: An environment variable is not present.\n" +
+				"ERROR: A configuration file exists, but does not have an account set to current.\n" +
+				errMsg + "\n" +
+				"use the `bpcli account set` command to set an account to current in the config file.")
+		}
+	}
+
+	// No env variable, config file w/ current set
+	if !envExists && fileExists {
+		b, err := hasCurrent()
+		if err != nil {
+			return apiKey, err
+		}
+		if b == true {
+			return getCurrentFromConfig()
+		}
+	}
+
+	// Env variables exists, file exists
+	if envExists && fileExists {
+		os.Stderr.WriteString("WARNING: An environment variable is set and a configuration file exists\n" +
+			"The environment variable will ALWAYS take precedence over the configuration file\n" +
+			"If you would like to use the configuration file, remove the environment variable\n" +
+			"****COLLECTOR LIST****\n")
+
+		return apiKey, nil
+	}
+
+	return apiKey, nil
+}
+
+// SetCurrent sets a chosen account to be the current account being worked in
+func SetCurrent(name string) error {
+
+	currentList, err := read()
+	if err != nil {
+		return err
+	}
+
+	b, err := accountExists(name)
+	if err != nil {
+		return err
+	}
+	if b == true {
+		for i := range currentList {
+			if name == currentList[i].Name {
+				currentList[i].Current = true
+			} else {
+				currentList[i].Current = false
+			}
+		}
+
+		updatedListBytes, err := json.Marshal(currentList)
+		if err != nil {
+			return err
+		}
+
+		return write(updatedListBytes)
+	}
+
+	return nil
+}
+
+// read Returns an array of accounts read from the configuration file
+func read() ([]account, error) {
+	accountList := []account{}
+
+	dir, err := homeDir()
+	if err != nil {
+		return accountList, err
+	}
+
+	file, err := ioutil.ReadFile(dir + "/.bpcli")
+	if err != nil {
+		return accountList, err
+	}
+	if len(file) == 0 {
+		return accountList, nil
+	}
+
+	return accountList, json.Unmarshal(file, &accountList)
+}
+
+// write is a helper function that will write/re-write the configuration file
+func write(list []byte) error {
+
+	dir, err := homeDir()
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(dir+"/.bpcli", list, 0644)
+}
+
+// uniqueUUID checks the account list for duplicate UUIDs
+func uniqueUUID(key string) (bool, error) {
+
+	currentList, err := read()
+	if err != nil {
+		return false, err
+	}
+
+	if uuid.IsUUID(key) {
+		for _, acc := range currentList {
+			if key == acc.Key {
+				return false, nil
+			}
+		}
+	} else {
+		return false, errors.New("The value given was not a valid UUID")
+	}
+
+	return true, nil
+}
+
+// uniqueName checks the users account list for duplicate names
+func uniqueName(name string) (bool, error) {
+
+	currentList, err := read()
+	if err != nil {
+		return false, err
+	}
+
+	for _, acc := range currentList {
+		if name == acc.Name {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// getCurrentFromConfig retrieves the currently active/set API key from the
+// config file
+func getCurrentFromConfig() (string, error) {
+	var currentKey string
+
+	currentList, err := read()
+	if err != nil {
+		return currentKey, err
+	}
+
+	for i := range currentList {
+		if currentList[i].Current == false {
+			continue
+		} else {
+			currentKey = currentList[i].Key
+		}
+	}
+
+	return currentKey, nil
+}
+
+func hasCurrent() (bool, error) {
+
+	currentList, err := read()
+	if err != nil {
+		return false, err
+	}
+
+	for i := range currentList {
+		if currentList[i].Current == false {
+			continue
+		} else {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// homeDir returns the home directory of the current user
+func homeDir() (string, error) {
+
+	usr, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+
+	dir := usr.HomeDir
+	return dir, nil
+}
+
+// accountExists checks the config file to see whether a given account exists
+func accountExists(name string) (bool, error) {
+
+	currentList, err := read()
+	if err != nil {
+		return false, err
+	}
+
+	for i := range currentList {
+		if name != currentList[i].Name {
+			continue
+		} else {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// checkConfig determines if a config file exists and whether it is empty
+func checkConfig() (bool, error) {
+
+	file, err := read()
+	if err != nil {
+		return false, err
+	}
+
+	if !(len(file) > 0) {
+		return true, errors.New("The accounts list is empty")
+	}
+
+	return true, nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -15,9 +15,9 @@ import (
 
 // account stores users BindPlane account information
 type account struct {
-	Name    string //`json:”name”`
-	Key     string //`json:”key”`
-	Current bool   //`json:”current”`
+	Name    string `json:"name"`
+	Key     string `json:"key"`
+	Current bool   `json:"current"`
 }
 
 // ListAccounts prints a formatted list of users read from the configuration file

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"os/user"
 
@@ -14,9 +15,9 @@ import (
 
 // account stores users BindPlane account information
 type account struct {
-	Name    string `json:”name”`
-	Key     string `json:”key”`
-	Current bool   `json:”current”`
+	Name    string //`json:”name”`
+	Key     string //`json:”key”`
+	Current bool   //`json:”current”`
 }
 
 // ListAccounts prints a formatted list of users read from the configuration file
@@ -27,8 +28,13 @@ func ListAccounts() error {
 		return err
 	}
 
+	path, err := configPath()
+	if err != nil {
+		return err
+	}
+
 	if len(currentList) == 0 {
-		return errors.New(`the file is empty! try adding a new account to the list`)
+		return errors.New(path + " is empty! try adding a new account to the list\n")
 	}
 
 	fmt.Println("List of Account Names. * Denotes Current Account")
@@ -49,7 +55,30 @@ func AddAccount(name string, key string) error {
 
 	currentList, err := read()
 	if err != nil {
+		os.Stderr.WriteString("ERROR: " + err.Error() + "\n")
+
+		path, err := configPath()
+		if err != nil {
+			return err
+		}
+
+		emptyFile, err := os.Create(path)
+		if err != nil {
+			log.Fatal(err)
+			os.Exit(1)
+		}
+
+		os.Stderr.WriteString("Creating a new file at: " + path + "\n")
+		emptyFile.Close()
+	}
+
+	currentList, err = read()
+	if err != nil {
 		return err
+	}
+
+	if len(name) == 0 {
+		return errors.New("The name cannot be an empty string")
 	}
 
 	if !uuid.IsUUID(key) {

--- a/config/config.go
+++ b/config/config.go
@@ -149,8 +149,8 @@ func Remove(name string) error {
 	return write(newListBytes)
 }
 
-// GetCurrentAPIKey attempts to retrieve an API key
-func GetCurrentAPIKey() (string, error) {
+// CurrentAPIKey attempts to retrieve an API key
+func CurrentAPIKey() (string, error) {
 
 	errMsg := `To use bpcli you must do either of the following:
 	1. Set an environment variable named BINDPLANE_API_KEY

--- a/config/config.go
+++ b/config/config.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"os/user"
+	"strings"
 
 	"github.com/BlueMedoraPublic/bpcli/util/uuid"
 	"github.com/google/go-cmp/cmp"
@@ -77,7 +78,7 @@ func AddAccount(name string, key string) error {
 		return err
 	}
 
-	if len(name) == 0 {
+	if len(strings.TrimSpace(name)) == 0 {
 		return errors.New("The name cannot be an empty string")
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"os/exec"
+	"testing"
+)
+
+//Writes tests for all functions within config.go
+
+//Will need to execute a bash script to set the file being tested back to
+//it's original state
+var delScript = exec.Command("/bin/sh", dir+"/test-file-delete")
+var resetScript = exec.Command("/bin/sh", dir+"/test-file-reset")
+
+// TestListAccounts tests for missing/non-existing config file
+func TestListAccounts(t *testing.T) {
+	//Remove the .bpcli file for testing
+	delScript.Run()
+
+	err := ListAccounts()
+	if err == nil {
+		t.Errorf("The function should return an error")
+	}
+
+	// Reset .bpcli file
+	resetScript.Run()
+}
+
+// TestListAccounts2 tests for any errors when a file exists
+func TestListAccounts2(t *testing.T) {
+
+	err := ListAccounts()
+	if err != nil {
+		t.Errorf("The function should not be returning an error if file exists")
+	}
+}
+
+// TestRemove tests the remove function in config.go
+// func TestRemove(t *testing.T) {
+// 	err := Remove("no-exist")
+// 	if err != nil {
+// 		t.Errorf("This file does not exist, but the function should not return an error")
+// 	}
+// }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -47,8 +47,8 @@ func TestListAccounts2(t *testing.T) {
 	createConfigFile()
 
 	err := ListAccounts()
-	if err != nil {
-		t.Errorf("The function should not be returning an error if file is empty")
+	if err == nil {
+		t.Errorf(err.Error())
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	//"os/exec"
+	"encoding/json"
 	"log"
 	"os"
 	"testing"
@@ -27,18 +28,11 @@ var testFile = []account{
 	},
 }
 
-//Writes tests for all functions within config.go
-
-//Will need to execute a bash script to set the file being tested back to
-//it's original state
-//var delScript = exec.Command("/bin/sh", dir+"/test-file-delete")
-//var resetScript = exec.Command("/bin/sh", dir+"/test-file-reset")
-
 // TestListAccounts tests for missing/non-existing config file
 func TestListAccounts(t *testing.T) {
 
 	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
-	createConfigFile()
+	os.Remove(configFile)
 
 	err := ListAccounts()
 	if err == nil {
@@ -46,22 +40,273 @@ func TestListAccounts(t *testing.T) {
 	}
 }
 
-// TestListAccounts2 tests for any errors when a file exists
-/*func TestListAccounts2(t *testing.T) {
+// TestListAccounts2 tests for any errors when a file is empty
+func TestListAccounts2(t *testing.T) {
+
+	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
+	createConfigFile()
 
 	err := ListAccounts()
 	if err != nil {
-		t.Errorf("The function should not be returning an error if file exists")
+		t.Errorf("The function should not be returning an error if file is empty")
 	}
-}*/
+}
 
-// TestRemove tests the remove function in config.go
-// func TestRemove(t *testing.T) {
-// 	err := Remove("no-exist")
-// 	if err != nil {
-// 		t.Errorf("This file does not exist, but the function should not return an error")
-// 	}
-// }
+// TestListAccounts3 tests for reading a file that is not empty
+func TestListAccounts3(t *testing.T) {
+
+	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
+	createConfigFile()
+	resetConfigFile()
+
+	err := ListAccounts()
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+}
+
+// TestAddAccount tests for file creation if one is missing
+func TestAddAccount(t *testing.T) {
+
+	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
+	os.Remove(configFile)
+
+	err := AddAccount("test4", "74a1aee1-ee9b-462f-88dc-65773eada2d7")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+}
+
+// TestAddAccount2 tests for empty name string
+func TestAddAccount2(t *testing.T) {
+
+	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
+	createConfigFile()
+	resetConfigFile()
+
+	err := AddAccount("", "74a1aee1-ee9b-462f-88dc-65773eada2d7")
+	if err == nil {
+		t.Errorf(err.Error())
+	}
+
+	os.Remove(configFile)
+}
+
+// TestAddAccount3
+func TestAddAccount3(t *testing.T) {
+
+	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
+	createConfigFile()
+	resetConfigFile()
+
+	err := AddAccount("test4", "74a1aee1-ee9b37489375%^^&%^&%")
+	if err == nil {
+		t.Errorf(err.Error())
+	}
+
+	os.Remove(configFile)
+}
+
+// TestAddAccount4
+func TestAddAccount4(t *testing.T) {
+
+	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
+	createConfigFile()
+	resetConfigFile()
+
+	err := AddAccount("test4", "43c009e8-40f3-4506-93ef-411299cf4181")
+	if err == nil {
+		t.Errorf(err.Error())
+	}
+
+	os.Remove(configFile)
+}
+
+// TestAddAccount5
+func TestAddAccount5(t *testing.T) {
+
+	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
+	createConfigFile()
+	resetConfigFile()
+
+	err := AddAccount("test1", "74a1aee1-ee9b-462f-88dc-65773eada2d7")
+	if err == nil {
+		t.Errorf(err.Error())
+	}
+
+	os.Remove(configFile)
+}
+
+// TestRemove tests the removing an account from empty file
+func TestRemove(t *testing.T) {
+
+	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
+	createConfigFile()
+
+	err := Remove("no-exist")
+	if err == nil {
+		t.Errorf("This file does exist, but the function should return an error")
+	}
+
+	os.Remove(configFile)
+}
+
+// TestRemove2
+func TestRemove2(t *testing.T) {
+
+	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
+	createConfigFile()
+	resetConfigFile()
+
+	err := Remove("test1")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	os.Remove(configFile)
+}
+
+// TestRemove3
+func TestRemove3(t *testing.T) {
+
+	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
+	createConfigFile()
+	resetConfigFile()
+
+	err := Remove("no-exist")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	os.Remove(configFile)
+}
+
+// TestSetCurrent sets an account to current that exists
+func TestSetCurrent(t *testing.T) {
+
+	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
+	createConfigFile()
+	resetConfigFile()
+
+	err := SetCurrent("test1")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	os.Remove(configFile)
+}
+
+// TestSetCurrent2
+func TestSetCurrent2(t *testing.T) {
+
+	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
+	createConfigFile()
+	resetConfigFile()
+
+	err := SetCurrent("no-exist")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	os.Remove(configFile)
+}
+
+// TestCurrentAPIKey no file, no env variable
+func TestCurrentAPIKey(t *testing.T) {
+
+	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
+	os.Unsetenv("BINDPLANE_API_KEY")
+
+	_, err := CurrentAPIKey()
+	if err == nil {
+		t.Errorf(err.Error())
+	}
+}
+
+// TestCurrentAPIKey2 no file, env variable exists
+func TestCurrentAPIKey2(t *testing.T) {
+
+	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
+	os.Setenv("BINDPLANE_API_KEY", "43c009e8-40f3-4506-93ef-411299cf4181")
+
+	_, err := CurrentAPIKey()
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+}
+
+// TestCurrentAPIKey3 no file, bad env variable exists
+func TestCurrentAPIKey3(t *testing.T) {
+
+	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
+	os.Setenv("BINDPLANE_API_KEY", "")
+
+	_, err := CurrentAPIKey()
+	if err == nil {
+		t.Errorf(err.Error())
+	}
+}
+
+// TestCurrentAPIKey4 no file, bad env variable exists
+func TestCurrentAPIKey4(t *testing.T) {
+
+	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
+	os.Setenv("BINDPLANE_API_KEY", "1")
+
+	_, err := CurrentAPIKey()
+	if err == nil {
+		t.Errorf(err.Error())
+	}
+}
+
+// TestCurrentAPIKey5 no env variable, file exists
+func TestCurrentAPIKey5(t *testing.T) {
+
+	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
+	os.Unsetenv("BINDPLANE_API_KEY")
+	createConfigFile()
+	resetConfigFile()
+
+	_, err := CurrentAPIKey()
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	os.Remove(configFile)
+}
+
+// TestCurrentAPIKey6 no env variable, file exists, no current
+func TestCurrentAPIKey6(t *testing.T) {
+
+	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
+	os.Unsetenv("BINDPLANE_API_KEY")
+	createConfigFile()
+	resetConfigFile()
+
+	Remove("test3")
+
+	_, err := CurrentAPIKey()
+	if err == nil {
+		t.Errorf(err.Error())
+	}
+
+	os.Remove(configFile)
+}
+
+// TestCurrentAPIKey7 env variable and file exist
+func TestCurrentAPIKey7(t *testing.T) {
+
+	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
+	os.Setenv("BINDPLANE_API_KEY", "43c009e8-40f3-4506-93ef-411299cf4181")
+	createConfigFile()
+	resetConfigFile()
+
+	_, err := CurrentAPIKey()
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	os.Remove(configFile)
+}
 
 func createConfigFile() {
 	emptyFile, err := os.Create(configFile)
@@ -72,6 +317,12 @@ func createConfigFile() {
 	emptyFile.Close()
 }
 
-func cleanconfigFile() {
+func resetConfigFile() error {
 
+	testListBytes, err := json.Marshal(testFile)
+	if err != nil {
+		return err
+	}
+
+	return write(testListBytes)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	//"os/exec"
 	"encoding/json"
 	"log"
 	"os"
@@ -28,48 +27,73 @@ var testFile = []account{
 	},
 }
 
-// TestListAccounts tests for missing/non-existing config file
-func TestListAccounts(t *testing.T) {
+/*
+TestListAccountsMissingFile: tests for missing/non-existing config file
+-------------------------------------------
+Produces an error message explaining that the file being read does
+not exist
+*/
+func TestListAccountsMissingFile(t *testing.T) {
 
 	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
-	os.Remove(configFile)
+	if err := createConfigFile(); err != nil {
+		t.Errorf(err.Error())
+	}
+	if err := os.Remove(configFile); err != nil {
+		t.Errorf(err.Error())
+	}
 
 	err := ListAccounts()
 	if err == nil {
+		t.Errorf("An error should have occurred when reading a file that does not exist")
+	}
+}
+
+/*
+TestListAccountsFileEmpty: tests for any errors when a file is empty
+Produces an error explaining that file being read does exist, but is empty.
+*/
+func TestListAccountsFileEmpty(t *testing.T) {
+
+	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
+	if err := createConfigFile(); err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if err := ListAccounts(); err == nil {
+		t.Errorf("An error should have occurred explaining that the file is empty")
+	}
+}
+
+/*
+TestListAccountsFileNotEmpty: tests for reading a file that is not empty
+Displays a list of accounts that exist within the file that is being read.
+*/
+func TestListAccountsFileNotEmpty(t *testing.T) {
+
+	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
+	if err := createConfigFile(); err != nil {
+		t.Errorf(err.Error())
+	}
+	if err := resetConfigFile(); err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if err := ListAccounts(); err != nil {
 		t.Errorf(err.Error())
 	}
 }
 
-// TestListAccounts2 tests for any errors when a file is empty
-func TestListAccounts2(t *testing.T) {
+/*
+TestAddAccountNoFileExists: tests for file creation if one is missing
+This should create a new configuration file and add the account to the file
+*/
+func TestAddAccountNoFileExists(t *testing.T) {
 
 	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
-	createConfigFile()
-
-	err := ListAccounts()
-	if err == nil {
+	if err := os.Remove(configFile); err != nil {
 		t.Errorf(err.Error())
 	}
-}
-
-// TestListAccounts3 tests for reading a file that is not empty
-func TestListAccounts3(t *testing.T) {
-
-	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
-	createConfigFile()
-	resetConfigFile()
-
-	err := ListAccounts()
-	if err != nil {
-		t.Errorf(err.Error())
-	}
-}
-
-// TestAddAccount tests for file creation if one is missing
-func TestAddAccount(t *testing.T) {
-
-	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
-	os.Remove(configFile)
 
 	err := AddAccount("test4", "74a1aee1-ee9b-462f-88dc-65773eada2d7")
 	if err != nil {
@@ -77,248 +101,421 @@ func TestAddAccount(t *testing.T) {
 	}
 }
 
-// TestAddAccount2 tests for empty name string
-func TestAddAccount2(t *testing.T) {
+/*
+TestAddAccountEmptyString: tests for empty name string
+-------------------------------------------
+Produces an error explaining that the name for an account must not be
+empty, or just all spaces, it must have characters.
+*/
+func TestAddAccountEmptyString(t *testing.T) {
 
 	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
-	createConfigFile()
-	resetConfigFile()
+	if err := createConfigFile(); err != nil {
+		t.Errorf(err.Error())
+	}
+	if err := resetConfigFile(); err != nil {
+		t.Errorf(err.Error())
+	}
 
 	err := AddAccount(" ", "74a1aee1-ee9b-462f-88dc-65773eada2d7")
 	if err == nil {
-		t.Errorf(err.Error())
+		t.Errorf("An error should have been produced, saying the name string cannot be empty")
 	}
 
-	os.Remove(configFile)
+	if err := os.Remove(configFile); err != nil {
+		t.Errorf(err.Error())
+	}
 }
 
-// TestAddAccount3
-func TestAddAccount3(t *testing.T) {
+/*
+TestAddAccountFalseUUID: tests trying to add an account where UUID is not valid
+Produces an error message explaining that the API Key given is not a valid UUID
+*/
+func TestAddAccountFalseUUID(t *testing.T) {
 
 	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
-	createConfigFile()
-	resetConfigFile()
+	if err := createConfigFile(); err != nil {
+		t.Errorf(err.Error())
+	}
+	if err := resetConfigFile(); err != nil {
+		t.Errorf(err.Error())
+	}
 
 	err := AddAccount("test4", "74a1aee1-ee9b37489375%^^&%^&%")
 	if err == nil {
-		t.Errorf(err.Error())
+		t.Errorf("Should produce an error message explaining the API Key is not" +
+			" a valid UUID")
 	}
 
-	os.Remove(configFile)
+	if err := os.Remove(configFile); err != nil {
+		t.Errorf(err.Error())
+	}
 }
 
-// TestAddAccount4
-func TestAddAccount4(t *testing.T) {
+/*
+TestAddAccountDuplicateUUID: tests adding an account with an already
+existing API Key
+-------------------------------------------
+Produces an error message saying that the API Key given already exists in the
+configuration file
+*/
+func TestAddAccountDuplicateUUID(t *testing.T) {
 
 	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
-	createConfigFile()
-	resetConfigFile()
+	if err := createConfigFile(); err != nil {
+		t.Errorf(err.Error())
+	}
+	if err := resetConfigFile(); err != nil {
+		t.Errorf(err.Error())
+	}
 
 	err := AddAccount("test4", "43c009e8-40f3-4506-93ef-411299cf4181")
 	if err == nil {
-		t.Errorf(err.Error())
+		t.Errorf("Should produce an error explaining the API Key given already" +
+			" exists in the configuration file")
 	}
 
-	os.Remove(configFile)
+	if err := os.Remove(configFile); err != nil {
+		t.Errorf(err.Error())
+	}
 }
 
-// TestAddAccount5
-func TestAddAccount5(t *testing.T) {
+/*
+TestAddAccountDuplicateName: tests adding an account with a name that
+already exists
+-------------------------------------------
+Produces an error message saying the name given already exists in the
+configuration file
+*/
+func TestAddAccountDuplicateName(t *testing.T) {
 
 	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
-	createConfigFile()
-	resetConfigFile()
+	if err := createConfigFile(); err != nil {
+		t.Errorf(err.Error())
+	}
+	if err := resetConfigFile(); err != nil {
+		t.Errorf(err.Error())
+	}
 
 	err := AddAccount("test1", "74a1aee1-ee9b-462f-88dc-65773eada2d7")
 	if err == nil {
+		t.Errorf("This test should fail, duplicate names are not allowed.")
+	}
+
+	if err := os.Remove(configFile); err != nil {
+		t.Errorf(err.Error())
+	}
+}
+
+/*
+TestRemoveFileEmpty: tests the removing an account from an empty file
+-------------------------------------------
+Produces an error explaining that the account given does not match any accounts
+that exist within the configuration file
+*/
+func TestRemoveFileEmpty(t *testing.T) {
+
+	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
+	if err := createConfigFile(); err != nil {
 		t.Errorf(err.Error())
 	}
 
-	os.Remove(configFile)
-}
-
-// TestRemove tests the removing an account from empty file
-func TestRemove(t *testing.T) {
-
-	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
-	createConfigFile()
-
-	err := Remove("no-exist")
-	if err == nil {
+	if err := Remove("no-exist"); err == nil {
 		t.Errorf("This file does exist, but the function should return an error")
 	}
 
-	os.Remove(configFile)
+	if err := os.Remove(configFile); err != nil {
+		t.Errorf(err.Error())
+	}
 }
 
-// TestRemove2
-func TestRemove2(t *testing.T) {
+/*
+TestRemoveExistingAccount: tests removing an existing account from the
+configuration file defined by the user.
+-------------------------------------------
+Remove the account named 'test1' from the configuration file.
+Return a nil error
+*/
+func TestRemoveExistingAccount(t *testing.T) {
 
 	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
-	createConfigFile()
-	resetConfigFile()
-
-	err := Remove("test1")
-	if err != nil {
+	if err := createConfigFile(); err != nil {
+		t.Errorf(err.Error())
+	}
+	if err := resetConfigFile(); err != nil {
 		t.Errorf(err.Error())
 	}
 
-	os.Remove(configFile)
-}
-
-// TestRemove3
-func TestRemove3(t *testing.T) {
-
-	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
-	createConfigFile()
-	resetConfigFile()
-
-	err := Remove("no-exist")
-	if err != nil {
+	if err := Remove("test1"); err != nil {
 		t.Errorf(err.Error())
 	}
 
-	os.Remove(configFile)
-}
-
-// TestSetCurrent sets an account to current that exists
-func TestSetCurrent(t *testing.T) {
-
-	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
-	createConfigFile()
-	resetConfigFile()
-
-	err := SetCurrent("test1")
-	if err != nil {
+	if err := os.Remove(configFile); err != nil {
 		t.Errorf(err.Error())
 	}
-	os.Remove(configFile)
 }
 
-// TestSetCurrent2
-func TestSetCurrent2(t *testing.T) {
+/*
+TestRemoveNonExistingAccount: tries to remove a non-existing account
+-------------------------------------------
+Produces an error message, explaining that the name is
+not present in the list of accounts.
+*/
+func TestRemoveNonExistingAccount(t *testing.T) {
 
 	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
-	createConfigFile()
-	resetConfigFile()
-
-	err := SetCurrent("no-exist")
-	if err != nil {
+	if err := createConfigFile(); err != nil {
+		t.Errorf(err.Error())
+	}
+	if err := resetConfigFile(); err != nil {
 		t.Errorf(err.Error())
 	}
 
-	os.Remove(configFile)
+	if err := Remove("no-exist"); err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if err := os.Remove(configFile); err != nil {
+		t.Errorf(err.Error())
+	}
 }
 
-// TestCurrentAPIKey no file, no env variable
-func TestCurrentAPIKey(t *testing.T) {
+/*
+TestSetCurrentExistingAccount: tests setting an account to current
+-------------------------------------------
+The account named 'test1' will be set as current
+in the list of accounts.
+*/
+func TestSetCurrentExistingAccount(t *testing.T) {
+
+	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
+	if err := createConfigFile(); err != nil {
+		t.Errorf(err.Error())
+	}
+	if err := resetConfigFile(); err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if err := SetCurrent("test1"); err != nil {
+		t.Errorf(err.Error())
+	}
+	if err := os.Remove(configFile); err != nil {
+		t.Errorf(err.Error())
+	}
+}
+
+/*
+TestSetCurrentNonExistingAccount: tests setting an account to current that does
+not exist in the configuration file
+-------------------------------------------
+Produces an error message, explaining that the name is
+not present in the configuration file.
+*/
+func TestSetCurrentNonExistingAccount(t *testing.T) {
+
+	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
+	if err := createConfigFile(); err != nil {
+		t.Errorf(err.Error())
+	}
+	if err := resetConfigFile(); err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if err := SetCurrent("no-exist"); err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if err := os.Remove(configFile); err != nil {
+		t.Errorf(err.Error())
+	}
+}
+
+/*
+TestCurrentAPIKey
+Case 1:
+No environment variable exists.
+No configuration file is present.
+-------------------------------------------
+Expected Behavior: Produce an error message
+*/
+func TestCurrentAPIKeyNoFileNoEnv(t *testing.T) {
 
 	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
 	os.Unsetenv("BINDPLANE_API_KEY")
 
-	_, err := CurrentAPIKey()
-	if err == nil {
-		t.Errorf(err.Error())
+	if _, err := CurrentAPIKey(); err == nil {
+		t.Errorf("This should produce an error message explaining that neither the" +
+			" configuration file, or environment variable, are present.")
 	}
 }
 
-// TestCurrentAPIKey2 no file, env variable exists
-func TestCurrentAPIKey2(t *testing.T) {
+/*
+TestCurrentAPIKeyNoFile
+Case 2:
+Environment variable is present
+No configuration file is present
+-------------------------------------------
+Expected Behavior: The API Key should be set using the environment
+variable that is defined, no errors.
+*/
+func TestCurrentAPIKeyNoFile(t *testing.T) {
 
 	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
 	os.Setenv("BINDPLANE_API_KEY", "43c009e8-40f3-4506-93ef-411299cf4181")
 
-	_, err := CurrentAPIKey()
-	if err != nil {
+	if _, err := CurrentAPIKey(); err != nil {
 		t.Errorf(err.Error())
 	}
 }
 
-// TestCurrentAPIKey3 no file, bad env variable exists
-func TestCurrentAPIKey3(t *testing.T) {
+/*
+TestCurrentAPIKeyNoFileEmptyEnv no file, empty env variable exists
+Case 2a:
+Environment Variable is present
+No configuration file exists
+Environment variable being passed is an empty string
+-------------------------------------------
+Expected Behavior: Produce an error saying that the API Key is not set
+*/
+func TestCurrentAPIKeyNoFileEmptyEnv(t *testing.T) {
 
 	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
 	os.Setenv("BINDPLANE_API_KEY", "")
 
-	_, err := CurrentAPIKey()
-	if err == nil {
-		t.Errorf(err.Error())
+	if _, err := CurrentAPIKey(); err == nil {
+		t.Errorf("This should have produced an error saying the API Key is not set")
 	}
 }
 
-// TestCurrentAPIKey4 no file, bad env variable exists
-func TestCurrentAPIKey4(t *testing.T) {
+/*
+TestCurrentAPIKeyNoFileBadEnv no file, bad env variable exists
+Case 2b:
+Environment Variable is present
+No configuration file exists
+Environment variable being passed is not a valid UUID
+-------------------------------------------
+Expected Behavior: Produce an error saying that the API Key is
+not a valid UUID
+*/
+func TestCurrentAPIKeyNoFileBadEnv(t *testing.T) {
 
 	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
 	os.Setenv("BINDPLANE_API_KEY", "1")
 
-	_, err := CurrentAPIKey()
-	if err == nil {
+	if _, err := CurrentAPIKey(); err == nil {
+		t.Errorf("Should produce an error explaining the API Key is not a valid UUID")
+	}
+}
+
+/*
+TestCurrentAPIKeyNoEnv no env variable, file exists
+Case 3:
+Environment variable is not present
+Configuration file exists
+Configuration file has valid data
+-------------------------------------------
+Expected Behavior: The API Key will be set using the configuration file that
+has been defined by the user.
+*/
+func TestCurrentAPIKeyNoEnv(t *testing.T) {
+
+	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
+	os.Unsetenv("BINDPLANE_API_KEY")
+	if err := createConfigFile(); err != nil {
+		t.Errorf(err.Error())
+	}
+	if err := resetConfigFile(); err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if _, err := CurrentAPIKey(); err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if err := os.Remove(configFile); err != nil {
 		t.Errorf(err.Error())
 	}
 }
 
-// TestCurrentAPIKey5 no env variable, file exists
-func TestCurrentAPIKey5(t *testing.T) {
+/*
+TestCurrentAPIKeyNoEnvNoCurrent no env variable, file exists
+Case 3a:
+Environment variable is not present
+Configuration file exists
+Configuration file has valid data
+Configuration file does not have an account with Current set to true
+-------------------------------------------
+Expected Behavior: Produce an error explaining that the configuration file is
+present, but does not have an account set to current
+*/
+func TestCurrentAPIKeyNoEnvNoCurrent(t *testing.T) {
 
 	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
 	os.Unsetenv("BINDPLANE_API_KEY")
-	createConfigFile()
-	resetConfigFile()
-
-	_, err := CurrentAPIKey()
-	if err != nil {
+	if err := createConfigFile(); err != nil {
+		t.Errorf(err.Error())
+	}
+	if err := resetConfigFile(); err != nil {
 		t.Errorf(err.Error())
 	}
 
-	os.Remove(configFile)
-}
-
-// TestCurrentAPIKey6 no env variable, file exists, no current
-func TestCurrentAPIKey6(t *testing.T) {
-
-	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
-	os.Unsetenv("BINDPLANE_API_KEY")
-	createConfigFile()
-	resetConfigFile()
-
+	// test3 is set to Current, so remove it for the test
 	Remove("test3")
 
-	_, err := CurrentAPIKey()
-	if err == nil {
-		t.Errorf(err.Error())
+	if _, err := CurrentAPIKey(); err == nil {
+		t.Errorf("An error should have occurred when trying to retrieve the API Key")
 	}
 
-	os.Remove(configFile)
+	if err := os.Remove(configFile); err != nil {
+		t.Errorf(err.Error())
+	}
 }
 
-// TestCurrentAPIKey7 env variable and file exist
-func TestCurrentAPIKey7(t *testing.T) {
+/*
+TestCurrentAPIKeyWarning env variable and file exist
+Case 4:
+Environment variable is present
+Environment variable is valid
+Configuration File is present
+Configuration File has valid data
+-------------------------------------------
+Expected Behavior: Print a warning to Stderr explaining that the environment
+variable will ALWAYS take precedence over the configuration file. Set the API
+Key using the environment variable and return a nil error
+*/
+func TestCurrentAPIKeyWarning(t *testing.T) {
 
 	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
 	os.Setenv("BINDPLANE_API_KEY", "43c009e8-40f3-4506-93ef-411299cf4181")
-	createConfigFile()
-	resetConfigFile()
-
-	_, err := CurrentAPIKey()
-	if err != nil {
+	if err := createConfigFile(); err != nil {
+		t.Errorf(err.Error())
+	}
+	if err := resetConfigFile(); err != nil {
 		t.Errorf(err.Error())
 	}
 
-	os.Remove(configFile)
+	if _, err := CurrentAPIKey(); err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if err := os.Remove(configFile); err != nil {
+		t.Errorf(err.Error())
+	}
 }
 
-func createConfigFile() {
+// createConfigFile is a helper function that creates the test configuration file
+func createConfigFile() error {
 	emptyFile, err := os.Create(configFile)
 	if err != nil {
 		log.Fatal(err)
 		os.Exit(1)
 	}
 	emptyFile.Close()
+	return nil
 }
 
+// resetConfigFile adds content to the file using testFile
 func resetConfigFile() error {
-
 	testListBytes, err := json.Marshal(testFile)
 	if err != nil {
 		return err

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -84,7 +84,7 @@ func TestAddAccount2(t *testing.T) {
 	createConfigFile()
 	resetConfigFile()
 
-	err := AddAccount("", "74a1aee1-ee9b-462f-88dc-65773eada2d7")
+	err := AddAccount(" ", "74a1aee1-ee9b-462f-88dc-65773eada2d7")
 	if err == nil {
 		t.Errorf(err.Error())
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,12 +2,30 @@ package config
 
 import (
 	//"os/exec"
-	"os"
 	"log"
+	"os"
 	"testing"
 )
 
 const configFile = "/tmp/.bpcli"
+
+var testFile = []account{
+	{
+		Name:    "test1",
+		Key:     "43c009e8-40f3-4506-93ef-411299cf4181",
+		Current: false,
+	},
+	{
+		Name:    "test2",
+		Key:     "024f5f47-e0e1-4f61-bf9c-39976db7f4a8",
+		Current: false,
+	},
+	{
+		Name:    "test3",
+		Key:     "91f5e858-eb9f-4136-8a37-bedeebbb7885",
+		Current: true,
+	},
+}
 
 //Writes tests for all functions within config.go
 
@@ -45,7 +63,6 @@ func TestListAccounts(t *testing.T) {
 // 	}
 // }
 
-
 func createConfigFile() {
 	emptyFile, err := os.Create(configFile)
 	if err != nil {
@@ -56,5 +73,5 @@ func createConfigFile() {
 }
 
 func cleanconfigFile() {
-	
+
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,39 +1,41 @@
 package config
 
 import (
-	"os/exec"
+	//"os/exec"
+	"os"
+	"log"
 	"testing"
 )
+
+const configFile = "/tmp/.bpcli"
 
 //Writes tests for all functions within config.go
 
 //Will need to execute a bash script to set the file being tested back to
 //it's original state
-var delScript = exec.Command("/bin/sh", dir+"/test-file-delete")
-var resetScript = exec.Command("/bin/sh", dir+"/test-file-reset")
+//var delScript = exec.Command("/bin/sh", dir+"/test-file-delete")
+//var resetScript = exec.Command("/bin/sh", dir+"/test-file-reset")
 
 // TestListAccounts tests for missing/non-existing config file
 func TestListAccounts(t *testing.T) {
-	//Remove the .bpcli file for testing
-	delScript.Run()
+
+	os.Setenv("BINDPLANE_CONFIG_FILE", configFile)
+	createConfigFile()
 
 	err := ListAccounts()
 	if err == nil {
-		t.Errorf("The function should return an error")
+		t.Errorf(err.Error())
 	}
-
-	// Reset .bpcli file
-	resetScript.Run()
 }
 
 // TestListAccounts2 tests for any errors when a file exists
-func TestListAccounts2(t *testing.T) {
+/*func TestListAccounts2(t *testing.T) {
 
 	err := ListAccounts()
 	if err != nil {
 		t.Errorf("The function should not be returning an error if file exists")
 	}
-}
+}*/
 
 // TestRemove tests the remove function in config.go
 // func TestRemove(t *testing.T) {
@@ -42,3 +44,17 @@ func TestListAccounts2(t *testing.T) {
 // 		t.Errorf("This file does not exist, but the function should not return an error")
 // 	}
 // }
+
+
+func createConfigFile() {
+	emptyFile, err := os.Create(configFile)
+	if err != nil {
+		log.Fatal(err)
+		os.Exit(1)
+	}
+	emptyFile.Close()
+}
+
+func cleanconfigFile() {
+	
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,8 @@ module github.com/BlueMedoraPublic/bpcli
 
 go 1.12
 
-require github.com/spf13/cobra v0.0.5
+require (
+	github.com/google/go-cmp v0.3.1
+	github.com/pkg/errors v0.8.1
+	github.com/spf13/cobra v0.0.5
+)

--- a/go.sum
+++ b/go.sum
@@ -6,12 +6,16 @@ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
+github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,7 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other review your Pull Request. -->

<!--- This template is based on github.com/zfsonlinux/zfs -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change solves the problem of always having to manually export an API Key for the BindPlane account being manipulated by bpcli

### Description
<!--- Describe your changes in detail -->
Added Config package to handle changes to the configuration file
Added Account related commands to the cmd package

### How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
Tested functionality by hand
Wrote Unit Tests for the Config package
Ran `make test`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code has been formatted with `make fmt` 
- [x] I have updated the documentation.
- [x] I have added / updated tests to cover my changes.
- [x] All new and existing tests passed with `make test`
- [x] All commit messages are clear concise


resolves https://github.com/BlueMedoraPublic/bpcli/issues/21