### PR TITLE
Api endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ a credentials file.
 
 *Warning*
 The **BINDPLANE_API_KEY** environment variable will always take precedence over the
-credentials file, if it is present. 
+credentials file, if it is present.
 
 #### Example Usage
 Adding and setting an account to be used by bpcli
@@ -163,6 +163,16 @@ export BINDPLANE_LIVE_TEST=1
 make test
 ```
 
+#### Alternative API
+
+If you wish to target an API other than the default ("https://public-api.bindplane.bluemedora.com/v1"),
+set the following environment variables:
+```
+export BINDPLANE_API_ENDPOINT="https://public-api.gcloud.bindplane.bluemedora.com"
+export BINDPLANE_API_VERSION="/v1"
+```
+
+`BINDPLANE_API_ENDPOINT` and `BINDPLANE_API_VERSION` can be set independently
 
 #### Build
 
@@ -179,7 +189,7 @@ Build with Docker, and check the artifacts directory when finished
 make
 ```
 
-To build on your own, without Docker, clone this repo *outside* of your GOPATH, as 
+To build on your own, without Docker, clone this repo *outside* of your GOPATH, as
 bpcli uses go modules:
 ```
 env CGO_ENABLED=0 go build -a

--- a/bindplane/api/api_test.go
+++ b/bindplane/api/api_test.go
@@ -4,23 +4,6 @@ import (
 	"testing"
 )
 
-func TestVersions(t *testing.T) {
-	x := Versions()
-	if len(x) != 1 {
-		t.Errorf("Expected Versions() to return a single api version as only '/v1' has been implemented")
-	}
-
-	foundV1 := false
-	for _, v := range x {
-		if v == "/v1" {
-			foundV1 = true
-		}
-	}
-	if foundV1 != true {
-		t.Errorf("Expected Versions() to include '/v1'")
-	}
-}
-
 func TestGetDefaultBaseURL(t *testing.T) {
 	x := GetDefaultBaseURL()
 	if x != defaultBaseURL {

--- a/bindplane/sdk/bindplane.go
+++ b/bindplane/sdk/bindplane.go
@@ -6,7 +6,6 @@ import (
 	"github.com/BlueMedoraPublic/bpcli/bindplane/api"
 	"github.com/BlueMedoraPublic/bpcli/config"
 	"github.com/BlueMedoraPublic/bpcli/util/httpclient"
-	"github.com/pkg/errors"
 )
 
 const bindplaneAPIEndpoint = "BINDPLANE_API_ENDPOINT"
@@ -42,10 +41,6 @@ func (bp *BindPlane) Init() error {
 
 	if err := bp.setAPIVersion(); err != nil {
 		return err
-	}
-
-	if apiVersionIsValid(bp.APIVersion) == false {
-		return errors.New("API Version " + bp.APIVersion + " is not valid.")
 	}
 
 	bp.paths.collectors = api.GetCollectorPath(bp.APIVersion)
@@ -116,13 +111,4 @@ func (bp *BindPlane) setAPIVersion() error {
 
 	bp.APIVersion = api.GetDefaultVersion()
 	return nil
-}
-
-func apiVersionIsValid(v string) bool {
-	for _, version := range api.Versions() {
-		if v == version {
-			return true
-		}
-	}
-	return false
 }

--- a/bindplane/sdk/bindplane.go
+++ b/bindplane/sdk/bindplane.go
@@ -10,6 +10,8 @@ import (
 )
 
 const bindplaneAPIEndpoint = "BINDPLANE_API_ENDPOINT"
+const bindplaneAPIVersion = "BINDPLANE_API_VERSION"
+
 
 // BindPlane type stores the global configuration
 type BindPlane struct {
@@ -40,6 +42,10 @@ func (bp *BindPlane) Init() error {
 
 	if err := bp.setAPIVersion(); err != nil {
 		return err
+	}
+
+	if apiVersionIsValid(bp.APIVersion) == false {
+		return errors.New("API Version " + bp.APIVersion + " is not valid.")
 	}
 
 	bp.paths.collectors = api.GetCollectorPath(bp.APIVersion)
@@ -98,15 +104,17 @@ func (bp *BindPlane) setAPIKey() error {
 }
 
 func (bp *BindPlane) setAPIVersion() error {
-	if len(bp.APIVersion) == 0 {
-		bp.APIVersion = api.GetDefaultVersion()
+	if len(bp.APIVersion) > 0 {
 		return nil
 	}
 
-	if apiVersionIsValid(bp.APIVersion) == false {
-		return errors.New("API Version " + bp.APIVersion + " is not valid.")
+	x := os.Getenv(bindplaneAPIVersion)
+	if len(x) > 0 {
+		bp.APIVersion = x
+		return nil
 	}
 
+	bp.APIVersion = api.GetDefaultVersion()
 	return nil
 }
 

--- a/bindplane/sdk/bindplane.go
+++ b/bindplane/sdk/bindplane.go
@@ -11,7 +11,6 @@ import (
 const bindplaneAPIEndpoint = "BINDPLANE_API_ENDPOINT"
 const bindplaneAPIVersion = "BINDPLANE_API_VERSION"
 
-
 // BindPlane type stores the global configuration
 type BindPlane struct {
 	BaseURL    string

--- a/bindplane/sdk/bindplane.go
+++ b/bindplane/sdk/bindplane.go
@@ -1,11 +1,15 @@
 package sdk
 
 import (
+	"os"
+
 	"github.com/BlueMedoraPublic/bpcli/bindplane/api"
 	"github.com/BlueMedoraPublic/bpcli/config"
 	"github.com/BlueMedoraPublic/bpcli/util/httpclient"
 	"github.com/pkg/errors"
 )
+
+const bindplaneAPIEndpoint = "BINDPLANE_API_ENDPOINT"
 
 // BindPlane type stores the global configuration
 type BindPlane struct {
@@ -58,7 +62,20 @@ func (bp BindPlane) APICall(method string, relativePath string, payload []byte) 
 }
 
 func (bp *BindPlane) setBaseURL() error {
-	if len(bp.BaseURL) == 0 {
+	// if already set programmatically
+	if len(bp.BaseURL) > 0 {
+		return nil
+	}
+
+	// if env is set
+	x := os.Getenv(bindplaneAPIEndpoint)
+	if len(x) > 0 {
+		bp.BaseURL = x
+		return nil
+	}
+
+	// set default
+	if len(bp.BaseURL) < 1 {
 		bp.BaseURL = api.GetDefaultBaseURL()
 	}
 	return nil

--- a/bindplane/sdk/bindplane_test.go
+++ b/bindplane/sdk/bindplane_test.go
@@ -1,10 +1,16 @@
 package sdk
 
 import (
+	"os"
 	"testing"
 )
 
 func TestInit(t *testing.T) {
+	if err := clearENV(); err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+
 	var bp BindPlane
 
 	err := bp.Init()
@@ -65,10 +71,49 @@ func TestInit(t *testing.T) {
 	if bp.APIKey != "ffae6858-1055-482a-90d0-826b20af2081" {
 		t.Errorf("Expected APIKey to be 'ffae6858-1055-482a-90d0-826b20af2081', got: " + bp.APIKey)
 	}
+}
 
-	bp.APIVersion = "v444"
-	err = bp.Init()
-	if err == nil {
-		t.Errorf("Expected APIVersion 'v444 to cause an error', APIVersion is set to: " + bp.APIVersion)
+func TestInitENV(t *testing.T) {
+	if err := clearENV(); err != nil {
+		t.Errorf(err.Error())
+		return
 	}
+
+	var bp BindPlane
+	base := "https://test.bindplane.bluemedora.com"
+	version := "/v2"
+
+	if err := os.Setenv(bindplaneAPIEndpoint, base); err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+
+	if err := os.Setenv(bindplaneAPIVersion, version); err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+
+	if err := bp.Init(); err != nil {
+		t.Errorf(err.Error())
+	}
+
+	if bp.BaseURL != base {
+		t.Errorf("Expected bp.BaseURL to match " + base + " but got " + bp.BaseURL)
+	}
+
+	if bp.APIVersion != version {
+		t.Errorf("Expected bp.BaseURL to match " + version + " but got " + bp.APIVersion)
+	}
+}
+
+func clearENV() error {
+	if err := os.Setenv(bindplaneAPIEndpoint, ""); err != nil {
+		return err
+	}
+
+	if err := os.Setenv(bindplaneAPIVersion, ""); err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
### Motivation and Context
resolves https://github.com/BlueMedoraPublic/bpcli/issues/24

### Description
bpcli will now use the following environment variables:
```
BINDPLANE_API_ENDPOINT
BINDPLANE_API_VERSION
```

These environment variables can be used together or on their own, they are not dependant upon each other.

example:
```
export BINDPLANE_API_ENDPOINT="https://public-api.gcloud.bindplane.bluemedora.com"
export BINDPLANE_API_VERSION="/v1"
```

Default values remain the same, the environment variables should only be used in situations where you are testing against an alternative API.

### How Has This Been Tested?
Updated tests and ran `make test`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code has been formatted with `make fmt` 
- [x] I have updated the documentation.
- [x] I have added / updated tests to cover my changes.
- [x] All new and existing tests passed with `make test`
- [x] All commit messages are clear concise


