### PR TITLE
use go 1.13 in order to leverage go module proxy, which is enabled by…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # staging environment retrieves dependencies and compiles
 #
-FROM golang:1.12
+FROM golang:1.13
 
 WORKDIR /build/src/github.com/BlueMedoraPublic/bpcli
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other review your Pull Request. -->

<!--- This template is based on github.com/zfsonlinux/zfs -->

### Motivation and Context
Sometimes `go build` fails due to 3rd party modules not being available temporarily (web server down for example). This causes a build failure that is not within our control.

Go 1.13 uses Google's module proxy by default. https://proxy.golang.org/

### Description
Updated `Dockerfile` to use `go 1.13` image

### How Has This Been Tested?
Passed `cloud build`

### Types of changes
Bug fix, related to the build process only, not bpcli's code.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [NA] My code has been formatted with `make fmt` 
- [NA] I have updated the documentation.
- [NA] I have added / updated tests to cover my changes.
- [X] All new and existing tests passed with `make test`
- [X] All commit messages are clear concise


