### PR TITLE
Source list json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # staging environment retrieves dependencies and compiles
 #
-FROM golang:1.12
+FROM golang:1.13
 
 WORKDIR /build/src/github.com/BlueMedoraPublic/bpcli
 

--- a/bindplane/sdk/collector.go
+++ b/bindplane/sdk/collector.go
@@ -1,9 +1,9 @@
 package sdk
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
-	"encoding/json"
 )
 
 // Collector type describes a collector configuration

--- a/bindplane/sdk/credential.go
+++ b/bindplane/sdk/credential.go
@@ -1,9 +1,9 @@
 package sdk
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
-	"encoding/json"
 )
 
 // Credential describes a source credential configuration

--- a/bindplane/sdk/jobs.go
+++ b/bindplane/sdk/jobs.go
@@ -1,9 +1,9 @@
 package sdk
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
-	"encoding/json"
 )
 
 // Job describes a job object

--- a/bindplane/sdk/source.go
+++ b/bindplane/sdk/source.go
@@ -1,10 +1,10 @@
 package sdk
 
 import (
-	"fmt"
-	"errors"
-	"net/http"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
 
 	"github.com/BlueMedoraPublic/bpcli/util/uuid"
 )

--- a/cmd/source_list.go
+++ b/cmd/source_list.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
-	"encoding/json"
 
 	"github.com/spf13/cobra"
 )

--- a/util/httpclient/http.go
+++ b/util/httpclient/http.go
@@ -18,7 +18,7 @@ func Request(method string, uri string, payload []byte, token string) ([]byte, e
 
 	body, status, err := performRequest(req)
 	if err != nil {
-		return nil, errors.Wrap(err, "error while making request to " + uri)
+		return nil, errors.Wrap(err, "error while making request to "+uri)
 	}
 
 	if StatusIs20X(status) == false {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other review your Pull Request. -->

<!--- This template is based on github.com/zfsonlinux/zfs -->

### Motivation and Context
A request was made to allow `--json` when calling `bpcli source list`, which traditionally gives a list. If you want to dump json of all your sources, you would have to do something like:
```
bpcli source list | xargs -n1 bpcli source get --json --id
```

Now you can do
```
bpcli source list --json

OR

bpcli source list --json | jq '.[3]'
```

This is an addition, that does not break backwards compatibility.

resolves https://github.com/BlueMedoraPublic/bpcli/issues/30

### Description
The source list command will check if the global variable `jsonFmt` has been set to true, if so, it will skip calling source.Print() and instead creating a json array of all sources, and then print the one json object.

Also refactored the error handling (minor change) for cmd/source_list.go

### How Has This Been Tested?
Used against a test environment with many sources. Parsed with jq. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code has been formatted with `make fmt` 
- [] I have updated the documentation.
- [] I have added / updated tests to cover my changes.
- [x] All new and existing tests passed with `make test`
- [x] All commit messages are clear concise


